### PR TITLE
Disable the launch of bareapp

### DIFF
--- a/src/bootd/sequencer/DefaultBootSequencer.cpp
+++ b/src/bootd/sequencer/DefaultBootSequencer.cpp
@@ -55,7 +55,9 @@ void DefaultBootSequencer::doBoot()
     g_Logger.infoLog(Logger::MSGID_BOOTSEQUENCER, "Bootd's job is done");
 
     ApplicationManager::instance()->listLaunchPoints(&m_bootManager, EventCoreTimeout::EventCoreTimeout_Max);
+    /* Disable the launch of bareapp since we don't include it in LuneOS images
     launchTargetApp();
+    */
 }
 
 void DefaultBootSequencer::launchTargetApp()


### PR DESCRIPTION
Works around the following:

Jun 17 10:48:12 qemux86-64 user.warn bootd: [] [pmlog] bootManager Jun 17 10:48:12 qemux86-64 user.warn bootd: [] [pmlog] bootManager BootSequencer {} Fail to launch 'bareapp'. Retry...(0)
Jun 17 10:48:12 qemux86-64 user.warn bootd: [] [pmlog] bootManager BootSequencer {} Fail to launch 'bareapp'. Retry...(1)
Jun 17 10:48:12 qemux86-64 user.warn bootd: [] [pmlog] bootManager BootSequencer {} Fail to launch 'bareapp'. Retry...(2)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>