### PR TITLE
Add system for LunaAppManager

### DIFF
--- a/files/sysbus/com.webos.bootd.perm.json
+++ b/files/sysbus/com.webos.bootd.perm.json
@@ -1,3 +1,3 @@
 {
-    "com.webos.bootManager": ["devices", "applications.internal", "settings", "activities", "networking.internal", "launcher.control", "launcher.status", "surfaces.control", "surfaces.status", "private"]
+    "com.webos.bootManager": ["devices", "applications.internal", "settings", "activities", "networking.internal", "launcher.control", "launcher.status", "surfaces.control", "surfaces.status", "private", "system"]
 }


### PR DESCRIPTION
To solve:May 18 09:07:12 qemux86-64 user.warn LunaAppManager: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.webos.bootManager","CATEGORY":"/","METHOD":"listLaunchPoints"} Service security groups don't allow method call.

Since listLaunchPoints is registered for "system" in LunaAppManager

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>